### PR TITLE
33149_fix_database_and_model

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -18,7 +18,7 @@ class Category extends Model
 
     public function childs()
     {
-        return $this->hasMany(Category::class);
+        return $this->hasMany(Category::class, 'parent_id');
     }
 
     public function books()

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -11,6 +11,16 @@ class Permission extends Model
 
     protected $guarded = [];
 
+    public function parent()
+    {
+        return $this->belongsTo(Permission::class);
+    }
+
+    public function childs()
+    {
+        return $this->hasMany(Permission::class, 'parent_id');
+    }
+
     public function users()
     {
         return $this->belongsToMany(User::class, 'user_permissions')->using(UserPermission::class);

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,7 +23,7 @@ class UserFactory extends Factory
     public function definition()
     {
         return [
-            'username' => $this->faker->name,
+            'username' => $this->faker->unique()->word,
             'email' => $this->faker->unique()->safeEmail,
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'first_name' => $this->faker->firstName,

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -36,6 +36,8 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('users');
+        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2021_01_04_061443_create_books_table.php
+++ b/database/migrations/2021_01_04_061443_create_books_table.php
@@ -32,6 +32,8 @@ class CreateBooksTable extends Migration
      */
     public function down()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('books');
+        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2021_01_04_061508_create_permissions_table.php
+++ b/database/migrations/2021_01_04_061508_create_permissions_table.php
@@ -15,8 +15,9 @@ class CreatePermissionsTable extends Migration
     {
         Schema::create('permissions', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('name')->unique();
             $table->string('description')->nullable();
+            $table->foreignId('parent_id')->nullable()->constrained('permissions');
         });
     }
 
@@ -27,6 +28,8 @@ class CreatePermissionsTable extends Migration
      */
     public function down()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('permissions');
+        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2021_01_04_061540_create_likes_table.php
+++ b/database/migrations/2021_01_04_061540_create_likes_table.php
@@ -29,8 +29,6 @@ class CreateLikesTable extends Migration
      */
     public function down()
     {
-        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('likes');
-        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2021_01_04_061550_create_reviews_table.php
+++ b/database/migrations/2021_01_04_061550_create_reviews_table.php
@@ -30,8 +30,6 @@ class CreateReviewsTable extends Migration
      */
     public function down()
     {
-        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('reviews');
-        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2021_01_04_063929_create_follows_table.php
+++ b/database/migrations/2021_01_04_063929_create_follows_table.php
@@ -29,8 +29,6 @@ class CreateFollowsTable extends Migration
      */
     public function down()
     {
-        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('follows');
-        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2021_01_04_065635_create_borrow_requests_table.php
+++ b/database/migrations/2021_01_04_065635_create_borrow_requests_table.php
@@ -17,12 +17,12 @@ class CreateBorrowRequestsTable extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained();
             $table->foreignId('book_id')->constrained();
-            $table->timestamp('from');
-            $table->timestamp('to');
+            $table->date('from');
+            $table->date('to');
             $table->string('note')->nullable();
             $table->boolean('status')->nullable();
-            $table->timestamp('processed_at');
-            $table->timestamp('returned_at');
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('returned_at')->nullable();
             $table->timestamp('created_at');
         });
     }

--- a/database/seeders/BookSeeder.php
+++ b/database/seeders/BookSeeder.php
@@ -14,14 +14,14 @@ class BookSeeder extends Seeder
     public function run()
     {
         $faker = \Faker\Factory::create();
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 100; $i++) {
             \App\Models\Book::create([
                 'title' => $faker->sentence,
                 'author_id' => $faker->randomDigit + 1,
                 'publisher_id' => $faker->randomDigit + 1,
                 'category_id' => $faker->randomDigit + 1,
                 'description' => $faker->paragraph,
-                'page_count' => $faker->numberBetween(10,100),
+                'page_count' => $faker->numberBetween(1, 1000),
             ]);
         }
     }

--- a/database/seeders/BorrowRequestSeeder.php
+++ b/database/seeders/BorrowRequestSeeder.php
@@ -15,16 +15,18 @@ class BorrowRequestSeeder extends Seeder
     {
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
-            \App\Models\BorrowRequest::create([
-                'user_id' => $faker->randomDigit + 1,
-                'book_id' => $faker->randomDigit + 1,
-                'from' => $faker->dateTime,
-                'to' => $faker->dateTime,
-                'note' => $faker->sentence,
-                'status' => $faker->boolean,
-                'processed_at' => $faker->dateTime,
-                'returned_at' => $faker->dateTime,
-            ]);
+            for ($j = 0; $j < 100; $j++) {
+                if ($faker->boolean) {
+                    \App\Models\BorrowRequest::create([
+                        'user_id' => $i + 1,
+                        'book_id' => $j + 1,
+                        'from' => $faker->dateTimeBetween('-30 days', "-5 days"),
+                        'to' => $faker->dateTimeBetween('+15 days', "+30 days"),
+                        'note' => $faker->sentence,
+                        'status' => false,
+                    ]);
+                }
+            }
         }
     }
 }

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -16,9 +16,9 @@ class CategorySeeder extends Seeder
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
             \App\Models\Category::create([
-                'name' => $faker->sentence,
+                'name' => $faker->word,
                 'description' => $faker->sentence,
-                'parent_id' => 1,
+                'parent_id' => $faker->boolean ? 1 : null,
             ]);
         }
     }

--- a/database/seeders/FollowSeeder.php
+++ b/database/seeders/FollowSeeder.php
@@ -16,13 +16,27 @@ class FollowSeeder extends Seeder
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
             \App\Models\Follow::create([
+                'user_id' => $i + 1,
+                'followable_id' => $faker->randomDigitNot($i + 1) + 1,
+                'followable_type' => 'user',
+                'followed_at' => $faker->unixTime,
+            ]);
+        }
+
+        for ($i = 0; $i < 100; $i++) {
+            \App\Models\Follow::create([
                 'user_id' => $faker->randomDigit + 1,
+                'followable_id' => $i + 1,
+                'followable_type' => 'book',
+                'followed_at' => $faker->unixTime,
+            ]);
+        }
+
+        for ($i = 0; $i < 10; $i++) {
+            \App\Models\Follow::create([
+                'user_id' => $i + 1,
                 'followable_id' => $faker->randomDigit + 1,
-                'followable_type' => $faker->randomElement([
-                    'user',
-                    'book',
-                    'author',
-                ]),
+                'followable_type' => 'author',
                 'followed_at' => $faker->unixTime,
             ]);
         }

--- a/database/seeders/ImageSeeder.php
+++ b/database/seeders/ImageSeeder.php
@@ -16,14 +16,33 @@ class ImageSeeder extends Seeder
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
             \App\Models\Image::create([
-                'path' => $faker->imageUrl(300, 300),
-                'imageable_id' => $faker->randomDigit + 1,
-                'imageable_type' => $faker->randomElement([
-                    'user',
-                    'book',
-                    'author',
-                    'publisher',
-                ]),
+                'path' => $faker->imageUrl(256, 256),
+                'imageable_id' => $i + 1,
+                'imageable_type' => 'user',
+            ]);
+        }
+
+        for ($i = 0; $i < 10; $i++) {
+            \App\Models\Image::create([
+                'path' => $faker->imageUrl(150, 100),
+                'imageable_id' => $i + 1,
+                'imageable_type' => 'category',
+            ]);
+        }
+
+        for ($i = 0; $i < 10; $i++) {
+            \App\Models\Image::create([
+                'path' => $faker->imageUrl(150, 100),
+                'imageable_id' => $i + 1,
+                'imageable_type' => 'publisher',
+            ]);
+        }
+
+        for ($i = 0; $i < 100; $i++) {
+            \App\Models\Image::create([
+                'path' => $faker->imageUrl(1280, 2048),
+                'imageable_id' => $i + 1,
+                'imageable_type' => 'book',
             ]);
         }
     }

--- a/database/seeders/LikeSeeder.php
+++ b/database/seeders/LikeSeeder.php
@@ -15,11 +15,15 @@ class LikeSeeder extends Seeder
     {
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
-            \App\Models\Like::create([
-                'user_id' => $faker->randomDigit + 1,
-                'book_id' => $faker->randomDigit + 1,
-                'liked_at' => $faker->unixTime,
-            ]);
+            for ($j = 0; $j < 100; $j++) {
+                if ($faker->boolean) {
+                    \App\Models\Like::create([
+                        'user_id' => $i + 1,
+                        'book_id' => $j + 1,
+                        'liked_at' => $faker->unixTime,
+                    ]);
+                }
+            }
         }
     }
 }

--- a/database/seeders/PublisherSeeder.php
+++ b/database/seeders/PublisherSeeder.php
@@ -16,7 +16,7 @@ class PublisherSeeder extends Seeder
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
             \App\Models\Publisher::create([
-                'name' => $faker->sentence,
+                'name' => $faker->words(2, true),
                 'description' => $faker->paragraph,
             ]);
         }

--- a/database/seeders/ReviewSeeder.php
+++ b/database/seeders/ReviewSeeder.php
@@ -15,13 +15,17 @@ class ReviewSeeder extends Seeder
     {
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
-            \App\Models\Review::create([
-                'user_id' => $faker->randomDigit + 1,
-                'book_id' => $faker->randomDigit + 1,
-                'rating' => $faker->numberBetween(0, 5),
-                'comment' => $faker->paragraph,
-                'reviewed_at' => $faker->unixTime,
-            ]);
+            for ($j = 0; $j < 100; $j++) {
+                if ($faker->boolean) {
+                    \App\Models\Review::create([
+                        'user_id' => $i + 1,
+                        'book_id' => $j + 1,
+                        'rating' => $faker->numberBetween(1, 5),
+                        'comment' => $faker->paragraph,
+                        'reviewed_at' => $faker->unixTime,
+                    ]);
+                }
+            }
         }
     }
 }

--- a/database/seeders/UserPermissionSeeder.php
+++ b/database/seeders/UserPermissionSeeder.php
@@ -16,8 +16,8 @@ class UserPermissionSeeder extends Seeder
         $faker = \Faker\Factory::create();
         for ($i = 0; $i < 10; $i++) {
             \App\Models\UserPermission::create([
-                'user_id' => $faker->randomDigit + 1,
-                'permission_id' => $faker->randomDigit + 1,
+                'user_id' => $i + 1,
+                'permission_id' => $faker->unique()->randomDigit + 1,
             ]);
         }
     }


### PR DESCRIPTION
- Thêm foreign key argument cho hàm `hasMany` ở `Category#childs`
- Thêm mối quan hệ một-nhiều vào Permission model, parent Permission có thể làm tất cả những gì mà child Permission có thể làm
- Sửa lại hàm `down` ở migrations: hàm `Schema::disableForeignKeyConstraints()` và `Schema::enableForeignKeyConstraints()` bị đặt sai
- Thêm số lượng dữ liệu giả; sửa lại một chút logic của dữ liệu; tránh trùng lặp ở các bảng phụ