### PR TITLE
hasimage_trait

### DIFF
--- a/app/Models/Author.php
+++ b/app/Models/Author.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasImage;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Model;
 
 class Author extends Model
 {
+    use HasImage;
 
     public $timestamps = false;
 
@@ -25,20 +26,9 @@ class Author extends Model
         });
     }
 
-    public function image()
-    {
-        return $this->morphOne(Image::class, 'imageable');
-    }
-
     public function getAvatarAttribute()
     {
-        $model = $this;
-        return Cache::remember("author-{$model->id}-avatar", config('app.cache-time'), function () use ($model) {
-            $imagePath = optional($model->image)->path ?? '';
-            return !empty($imagePath)
-                    ? asset("storage/{$imagePath}")
-                    : asset('storage/'. config('app.default-image.author'));
-        });
+        return $this->image;
     }
 
     public function books()

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -2,28 +2,19 @@
 
 namespace App\Models;
 
+use App\Traits\HasImage;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Model;
 
 class Book extends Model
 {
+    use HasImage;
 
     protected $guarded = [];
 
-    public function image()
-    {
-        return $this->morphOne(Image::class, 'imageable');
-    }
-
     public function getCoverAttribute()
     {
-        $model = $this;
-        return Cache::remember("book-{$model->id}-cover", config('app.cache-time'), function () use ($model) {
-            $imagePath = optional($model->image)->path ?? '';
-            return !empty($imagePath)
-                    ? asset("storage/{$imagePath}")
-                    : asset('storage/'. config('app.default-image.book'));
-        });
+        return $this->image;
     }
 
     public function author()

--- a/app/Models/Publisher.php
+++ b/app/Models/Publisher.php
@@ -2,30 +2,20 @@
 
 namespace App\Models;
 
-use Illuminate\Support\Facades\Cache;
+use App\Traits\HasImage;
 use Illuminate\Database\Eloquent\Model;
 
 class Publisher extends Model
 {
+    use HasImage;
 
     public $timestamps = false;
 
     protected $guarded = [];
 
-    public function image()
-    {
-        return $this->morphOne(Image::class, 'imageable');
-    }
-
     public function getLogoAttribute()
     {
-        $model = $this;
-        return Cache::remember("publisher-{$model->id}-logo", config('app.cache-time'), function () use ($model) {
-            $imagePath = optional($model->image)->path ?? '';
-            return !empty($imagePath)
-                    ? asset("storage/{$imagePath}")
-                    : asset('storage/'. config('app.default-image.publisher'));
-        });
+        return $this->image;
     }
 
     public function books()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,17 +2,17 @@
 
 namespace App\Models;
 
+use App\Traits\HasImage;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasImage;
 
     protected $guarded = [];
 
@@ -37,20 +37,9 @@ class User extends Authenticatable
         });
     }
 
-    public function image()
-    {
-        return $this->morphOne(Image::class, 'imageable');
-    }
-
     public function getAvatarAttribute()
     {
-        $model = $this;
-        return Cache::remember("{$model->id}-avatar", config('app.cache-time'), function () use ($model) {
-            $imagePath = optional($model->image)->path ?? '';
-            return !empty($imagePath)
-                    ? asset("storage/{$imagePath}")
-                    : asset('storage/'. config('app.default-image.user'));
-        });
+        return $this->image;
     }
 
     public function permissions()

--- a/app/Traits/HasImage.php
+++ b/app/Traits/HasImage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Image;
+use Illuminate\Support\Facades\Cache;
+
+trait HasImage
+{
+
+    public function image()
+    {
+        return $this->morphOne(Image::class, 'imageable');
+    }
+
+    public function getImageAttribute()
+    {
+        $model = $this;
+        $cacheKey = get_class($this) .'.'. $this->id;
+        return Cache::remember($cacheKey, config('app.cache-time'), function () use ($model) {
+            $imagePath = optional($model->image()->first())->path ?? '';
+            return !empty($imagePath)
+                    ? asset("storage/{$imagePath}")
+                    : asset('storage/'. config('app.default-image.'. $model->getMorphClass()));
+        });
+    }
+
+    public function setImageAttribute($imagePath)
+    {
+        $image = $this->image();
+        if ($image->first()) {
+            if ($imagePath != config('app.default-image.'. $this->getMorphClass())) {
+                $image->update([
+                    'path' => $imagePath,
+                ]);
+            }
+        } else {
+            $image->create([
+                'path' => $imagePath,
+            ]);
+        }
+        Cache::forget(get_class($this) .'.'. $this->id);
+    }
+
+}

--- a/tests/Unit/Models/AuthorTest.php
+++ b/tests/Unit/Models/AuthorTest.php
@@ -52,16 +52,24 @@ class AuthorTest extends ModelTestCase
 
     public function test_author_has_default_avatar()
     {
-        $this->assertSame(asset('storage/'. config('app.default-image.author')), $this->model->avatar);
+        $default = asset('storage/'. config('app.default-image.author'));
+
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
+        Cache::shouldReceive('remember')
+                ->once()
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
+                ->andReturn($default);
+        $this->assertSame($default, $this->model->avatar);
     }
 
     public function test_author_avatar_is_cached()
     {
         $default = asset('storage/'. config('app.default-image.author'));
 
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
         Cache::shouldReceive('remember')
                 ->once()
-                ->with("author-{$this->model->id}-avatar", config('app.cache-time'), Closure::class)
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
                 ->andReturn($default);
         $this->assertSame($default, $this->model->avatar);
     }

--- a/tests/Unit/Models/BookTest.php
+++ b/tests/Unit/Models/BookTest.php
@@ -97,16 +97,24 @@ class BookTest extends ModelTestCase
 
     public function test_book_has_default_cover()
     {
-        $this->assertSame(asset('storage/'. config('app.default-image.book')), $this->model->cover);
+        $default = asset('storage/'. config('app.default-image.book'));
+
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
+        Cache::shouldReceive('remember')
+                ->once()
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
+                ->andReturn($default);
+        $this->assertSame($default, $this->model->cover);
     }
 
     public function test_book_cover_is_cached()
     {
         $default = asset('storage/'. config('app.default-image.book'));
 
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
         Cache::shouldReceive('remember')
                 ->once()
-                ->with("book-{$this->model->id}-cover", config('app.cache-time'), Closure::class)
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
                 ->andReturn($default);
         $this->assertSame($default, $this->model->cover);
     }

--- a/tests/Unit/Models/PublisherTest.php
+++ b/tests/Unit/Models/PublisherTest.php
@@ -46,16 +46,24 @@ class PublisherTest extends ModelTestCase
 
     public function test_publisher_has_default_logo()
     {
-        $this->assertSame(asset('storage/'. config('app.default-image.publisher')), $this->model->logo);
+        $default = asset('storage/'. config('app.default-image.publisher'));
+
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
+        Cache::shouldReceive('remember')
+                ->once()
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
+                ->andReturn($default);
+        $this->assertSame($default, $this->model->logo);
     }
 
     public function test_publisher_logo_is_cached()
     {
         $default = asset('storage/'. config('app.default-image.publisher'));
 
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
         Cache::shouldReceive('remember')
                 ->once()
-                ->with("publisher-{$this->model->id}-logo", config('app.cache-time'), Closure::class)
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
                 ->andReturn($default);
         $this->assertSame($default, $this->model->logo);
     }

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -94,16 +94,24 @@ class UserTest extends ModelTestCase
 
     public function test_user_has_default_avatar()
     {
-        $this->assertSame(asset('storage/'. config('app.default-image.user')), $this->model->avatar);
+        $default = asset('storage/'. config('app.default-image.user'));
+
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
+        Cache::shouldReceive('remember')
+                ->once()
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
+                ->andReturn($default);
+        $this->assertSame($default, $this->model->avatar);
     }
 
     public function test_user_avatar_is_cached()
     {
         $default = asset('storage/'. config('app.default-image.user'));
 
+        $cacheKey = get_class($this->model) .'.'. $this->model->id;
         Cache::shouldReceive('remember')
                 ->once()
-                ->with("{$this->model->id}-avatar", config('app.cache-time'), Closure::class)
+                ->with($cacheKey, config('app.cache-time'), Closure::class)
                 ->andReturn($default);
         $this->assertSame($default, $this->model->avatar);
     }


### PR DESCRIPTION
- Sử dụng trait `HasImage` cho các model có ảnh để tránh lặp code: `User`, `Book`, `Author`, `Publisher`
- Sửa lại unit test cho các model vì cache key thay đổi: `UserTest`, `BookTest`, `AuthorTest`, `PublisherTest`